### PR TITLE
Remove the built-in filters of .ultraThinMaterial to better control t…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MegaX",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v17), .macOS(.v14)
     ],
     products: [
         .library(name: "MegaX", targets: ["MegaX"]),

--- a/Sources/MegaX/Environment/PlatformAlias.swift
+++ b/Sources/MegaX/Environment/PlatformAlias.swift
@@ -1,0 +1,19 @@
+//
+//  PlatformAlias.swift
+//
+//
+//  Created by tdt on 2024/3/2.
+//
+
+import Foundation
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+typealias PlatformViewRepresentable = UIViewRepresentable
+typealias PlatformVisualEffectView = UIVisualEffectView
+#elseif canImport(AppKit)
+import AppKit
+typealias PlatformViewRepresentable = NSViewRepresentable
+typealias PlatformVisualEffectView = NSVisualEffectView
+#endif

--- a/Sources/MegaX/Modifiers/BackdropBlur.swift
+++ b/Sources/MegaX/Modifiers/BackdropBlur.swift
@@ -49,7 +49,8 @@ struct BackdropBlurLayer: View {
     var body: some View {
         Color.clear
             // workaround: To avoid a occasional black background during rendering, place BackdropView in the .background.
-            .background(BackdropView().blur(radius: transparency.blurRadius, opaque: true))
+            .background(BackdropView().blur(radius: transparency.blurRadius, opaque: true).preferredColorScheme(.dark))
+            .preferredColorScheme(nil)
             .padding(smoothEdges.isEmpty ? 0 : -12)
             .mask {
                 Canvas { context, size in

--- a/Sources/MegaX/Modifiers/BackdropBlur.swift
+++ b/Sources/MegaX/Modifiers/BackdropBlur.swift
@@ -47,18 +47,9 @@ struct BackdropBlurLayer: View {
     var smoothEdges: Edge.Set
     
     var body: some View {
-        Rectangle()
-            .fill(.ultraThinMaterial)
-            .environment(\.colorScheme, .light)
-            // Remove extra effects from system Material
-            .grayscale(0.2)
-            .contrast(1.62)
-            .brightness(-0.254)
-            .saturation(1.4)
-            // Adds additional blur
-            .blur(radius: transparency.blurRadius, opaque: true)
-            .compositingGroup()
-            // Smooth edges
+        Color.clear
+            // workaround: To avoid a occasional black background during rendering, place BackdropView in the .background.
+            .background(BackdropView().blur(radius: transparency.blurRadius, opaque: true))
             .padding(smoothEdges.isEmpty ? 0 : -12)
             .mask {
                 Canvas { context, size in
@@ -120,6 +111,23 @@ struct BackdropBlurLayer: View {
                 }
             }
             .ignoresSafeArea()
+    }
+}
+
+struct BackdropView: UIViewRepresentable {
+    typealias UIViewType = UIVisualEffectView
+
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
+    }
+
+    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {
+        // inspired by https://stackoverflow.com/a/76658308/4728060
+        DispatchQueue.main.async {
+            if let backdropLayer = uiView.layer.sublayers?.first {
+                backdropLayer.filters? = []
+            }
+        }
     }
 }
 


### PR DESCRIPTION
移除使用默认的`.ultraThinMaterial`，因为默认的blur效果太强了且不可控。避免手动设置grayscale等参数，可以更自由添加更多滤镜效果。

左边是之前的效果，右边是新的效果。
![CleanShot 2024-03-02 at 18 34 09](https://github.com/LiYanan2004/MegaX/assets/10215098/3fb0d7ca-a9f0-4831-9331-62df925b79d4)
